### PR TITLE
README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following repository is a reduced test case for a bug in the [Cypress](https
 </head>
 <body>
   <h1>Homepage</h1>
-  <p>jQuery</p>
+  <p id="jquery">jQuery</p>
 </body>
 </html>
 ```


### PR DESCRIPTION
Readded missing `id` attribute to `<p>` tag in webpage's markup shown in the `README.md` file.